### PR TITLE
Put tuples in memory without serializing them

### DIFF
--- a/src/QueryLanguage/Fancy.hs
+++ b/src/QueryLanguage/Fancy.hs
@@ -2,6 +2,7 @@
 module QueryLanguage.Fancy where
 
 import qualified Control.Foldl as L
+import Control.Lens (Lens', lens, over)
 import Data.Binary
 import Data.Binary.Get (getInt64le, isolate)
 import Data.Binary.Put
@@ -59,19 +60,11 @@ type IsHeading heading k v =
   , Split k v heading
   , Unionable k v
   , Union k v ~ heading
-  , Binary (Tuple heading)
-  , Binary (Tuple k)
-  , Binary (Tuple v)
   )
 
-data Table heading k v where
-  MkTable :: forall (heading :: [Mapping Symbol Type]) k v. (IsHeading heading k v) => Table heading k v
+data Table heading k v = (IsHeading heading k v) => MkTable
 
-type family IsKey (labels :: [Symbol]) (t :: [Mapping Symbol Type]) :: Constraint where
-  IsKey (label ': ls) (label ::: a ': rest) = IsKey ls rest
-  IsKey (label ': ls) (a ': rest) = IsKey (label ': ls) rest
-  IsKey '[] tuple = ()
-  IsKey labels '[] = TypeError ( 'Text "Could not find " ':<>: 'ShowType labels)
+data TableOp heading k v = Insert (Tuple heading) | DeleteByKey (Tuple k)
 
 type family Rename (a :: Symbol) (b :: Symbol) (t :: [Mapping Symbol Type]) :: [Mapping Symbol Type] where
   Rename a b '[] = '[]
@@ -109,7 +102,14 @@ type family Intersection'Case (ordering :: Ordering) l r a as b bs where
   Intersection'Case 'EQ l r a as b bs = TypeError ( 'Text "Unreachable, oh god please")
 
 data Query (t :: [Mapping Symbol Type]) (tables :: [Mapping Symbol Type]) where
-  Identity :: ((tables :! name) ~ Table heading k v, KnownSymbol name) => Var name -> Table heading k v -> Query heading tables
+  Identity ::
+    ( (tables :! name) ~ Table heading k v
+    , IsMember name (Table heading k v) tables
+    , IsMember name (M.Map (Tuple k) (Tuple v)) (MemDB' tables)
+    ) =>
+    Var name ->
+    Table heading k v ->
+    Query heading tables
   Rename :: forall a b t tables. Var a -> Var b -> Query t tables -> Query (Rename a b t) tables
   Restrict :: (Tuple t -> Bool) -> Query t tables -> Query t tables
   Project :: (Submap t' t) => Query t tables -> Query t' tables
@@ -160,44 +160,42 @@ data Query (t :: [Mapping Symbol Type]) (tables :: [Mapping Symbol Type]) where
     Query t tables ->
     Query (nested :++ rest) tables
 
-data Database (tables :: [Mapping Symbol Type]) where
-  EmptyDB :: Database '[]
+data DBStatement (tables :: [Mapping Symbol Type]) where
+  EmptyDB :: DBStatement '[]
   CreateTable ::
-    (Member name tables ~ 'False, KnownSymbol name) =>
-    Var name ->
-    Table heading k v ->
-    Database tables ->
-    Database ((name ::: Table heading k v) ': tables)
+    (Member name tables ~ 'False, IsHeading heading k v, Ord (Tuple k)) =>
+    DBStatement tables ->
+    DBStatement ((name ::: Table heading k v) ': tables)
   DeleteTable ::
     forall (name :: Symbol) tables remaining.
-    (KnownSymbol name, Member name tables ~ 'True, (tables :\ name) ~ remaining) =>
+    (Member name tables ~ 'True, (tables :\ name) ~ remaining, Submap (MemDB' remaining) (MemDB' tables)) =>
     Var name ->
-    Database tables ->
-    Database remaining
-  Insert ::
-    ((tables :! name) ~ Table heading k v, KnownSymbol name) =>
+    Proxy remaining ->
+    DBStatement tables ->
+    DBStatement remaining
+  TableStatement ::
+    ( IsHeading heading k v
+    , (MemDB' tables :! name) ~ M.Map (Tuple k) (Tuple v)
+    , IsMember name (M.Map (Tuple k) (Tuple v)) (MemDB' tables)
+    , Updatable name (M.Map (Tuple k) (Tuple v)) (MemDB' tables) (MemDB' tables)
+    , Ord (Tuple k)
+    ) =>
     Var name ->
-    Table heading k v ->
-    Tuple heading ->
-    Database tables ->
-    Database tables
+    TableOp heading k v ->
+    DBStatement tables ->
+    DBStatement tables
 
-type family TableHeading table :: [Mapping Symbol Type] where
-  TableHeading (Table heading k v) = heading
-  TableHeading a = TypeError ( 'Text "Can only call 'TableHeading' on Table, not " ':$$: 'ShowType a)
+type family MemDB tables where
+  MemDB tables = Tuple (MemDB' tables)
 
-newtype MemDB tables = MemDB {getMemDB :: M.Map String (M.Map LByteString LByteString)}
-  deriving (Show)
+type family MemDB' tables where
+  MemDB' '[] = '[]
+  MemDB' (name ::: Table heading k v ': rest) = (name ::: M.Map (Tuple k) (Tuple v)) ': MemDB' rest
 
-runQuery ::
-  forall t tables tables'.
-  (Sort tables ~ Sort tables') =>
-  Query t tables ->
-  MemDB tables' ->
-  [Tuple t]
+runQuery :: forall tables t. Query t tables -> MemDB tables -> [Tuple t]
 runQuery q mem = case q of
   Identity name (MkTable :: Table heading k v) ->
-    M.toList (getMemDB mem M.! str name) & map \(k, v) -> (decode k :: Tuple k) `union` (decode v :: Tuple v)
+    M.toList (lookp name mem) & map \(k, v) -> (k :: Tuple k) `union` (v :: Tuple v)
   Rename Var Var q' -> unsafeCoerce $ runQuery q' mem
   Restrict pred q' -> filter pred (runQuery q' mem)
   Project q' -> map submap (runQuery q' mem)
@@ -232,19 +230,30 @@ runQuery q mem = case q of
           rest = submap @rest tuple
        in append nested rest
 
-materializeDB :: forall tables. Database tables -> MemDB tables
-materializeDB EmptyDB = MemDB mempty
-materializeDB (CreateTable name MkTable rest) =
-  MemDB $
-    M.insert (str name) mempty (getMemDB (materializeDB rest))
-materializeDB (DeleteTable name rest) = MemDB $ M.delete (str name) (getMemDB $ materializeDB rest)
-materializeDB (Insert name (MkTable :: Table heading k v) t rest) =
-  MemDB $
-    M.update (Just . M.insert (encode key) (encode val)) (str name) (getMemDB $ materializeDB rest)
-  where
-    kv :: (Split k v heading) => (Tuple k, Tuple v)
-    kv = split t
-    (key, val) = kv
+materializeDB :: forall tables. DBStatement tables -> MemDB tables
+materializeDB EmptyDB = Empty
+materializeDB (CreateTable rest) = Ext Var M.empty (materializeDB rest)
+materializeDB (DeleteTable _ (_ :: Proxy remaining) rest) = submap @(MemDB' remaining) (materializeDB rest)
+materializeDB (TableStatement name s rest) = over (colLens' name) (tableUpdate s) (materializeDB rest)
 
-str :: forall k. KnownSymbol k => Var k -> String
-str Var = symbolVal (Proxy @k)
+-- | Update the type at label l
+type family ChangeType (l :: Symbol) (t' :: Type) (t :: [Mapping Symbol Type]) where
+  ChangeType l a (l ::: b ': rest) = l ::: a ': rest
+  ChangeType l a (l' ::: b ': rest) = l' ::: b ': ChangeType l a rest
+  ChangeType l a '[] = '[]
+
+colLens' ::
+  forall (label :: Symbol) m t.
+  (IsMember label t m, t ~ (m :! label), Updatable label t m m) =>
+  Var label ->
+  Lens' (Tuple m) t
+colLens' var = lens (lookp var) (`update` var)
+
+tableUpdate ::
+  (IsHeading heading k v, Ord (Tuple k)) =>
+  TableOp heading k v ->
+  M.Map (Tuple k) (Tuple v) ->
+  M.Map (Tuple k) (Tuple v)
+tableUpdate (Insert tuple) =
+  let (key, val) = split tuple in M.insert key val
+tableUpdate (DeleteByKey key) = M.delete key

--- a/src/QueryLanguage/Fancy/API.hs
+++ b/src/QueryLanguage/Fancy/API.hs
@@ -35,9 +35,9 @@ insert ::
   forall name tables heading k v k_c v_c.
   ( IsHeading heading k v
   , Table heading k v ~ (tables :! name)
-  , (MemDB' tables :! name) ~ M.Map (Tuple k) (Tuple v)
-  , IsMember name (M.Map (Tuple k) (Tuple v)) (MemDB' tables)
-  , Updatable name (M.Map (Tuple k) (Tuple v)) (MemDB' tables) (MemDB' tables)
+  , (MapDB' tables :! name) ~ M.Map (Tuple k) (Tuple v)
+  , IsMember name (M.Map (Tuple k) (Tuple v)) (MapDB' tables)
+  , Updatable name (M.Map (Tuple k) (Tuple v)) (MapDB' tables) (MapDB' tables)
   , k_c (Tuple k)
   , v_c (Tuple v)
   ) =>
@@ -50,9 +50,9 @@ insertMany ::
   forall name tables heading k v t k_c v_c.
   ( IsHeading heading k v
   , Table heading k v ~ (tables :! name)
-  , (MemDB' tables :! name) ~ M.Map (Tuple k) (Tuple v)
-  , IsMember name (M.Map (Tuple k) (Tuple v)) (MemDB' tables)
-  , Updatable name (M.Map (Tuple k) (Tuple v)) (MemDB' tables) (MemDB' tables)
+  , (MapDB' tables :! name) ~ M.Map (Tuple k) (Tuple v)
+  , IsMember name (M.Map (Tuple k) (Tuple v)) (MapDB' tables)
+  , Updatable name (M.Map (Tuple k) (Tuple v)) (MapDB' tables) (MapDB' tables)
   , Foldable t
   , k_c (Tuple k)
   , v_c (Tuple v)
@@ -66,7 +66,7 @@ table ::
   forall name tables heading k v.
   ( (tables :! name) ~ Table heading k v
   , IsMember name (Table heading k v) tables
-  , IsMember name (M.Map (Tuple k) (Tuple v)) (MemDB' tables)
+  , IsMember name (M.Map (Tuple k) (Tuple v)) (MapDB' tables)
   , IsHeading heading k v
   ) =>
   Query heading tables
@@ -157,4 +157,4 @@ col = lens (lookp (Var @label)) (`update` (Var @label))
 
 -- for the repl
 testQuery :: Show (Tuple t) => DBStatement tables Ord v_c -> Query t tables -> IO ()
-testQuery db q = runQuery q (materializeMemDB db) & mapM_ Relude.print
+testQuery db q = runQuery q (materializeMapDB db) & mapM_ Relude.print

--- a/src/QueryLanguage/Fancy/API.hs
+++ b/src/QueryLanguage/Fancy/API.hs
@@ -7,51 +7,66 @@ module QueryLanguage.Fancy.API where
 
 import qualified Control.Foldl as L
 import Control.Lens (Lens, Lens', lens)
+import qualified Data.Map.Strict as M
 import Data.Type.Map
 import Data.Type.Set (AsSet, Sort, type (:++))
 import GHC.TypeLits
 import QueryLanguage.Fancy
 import Relude hiding (Identity, Map, get, put, undefined)
+import qualified Prelude as P
 
+{- | Intended usage is to have a named table type that you pass to 'createTable'
+ via type applications
+
+ > type UserTable = "users" ::: T '["id" ::: Int, "name" ::: String, "age" ::: Int] '["id"]
+ > createTable @UserTable
+-}
 createTable ::
-  forall table name heading k v tables.
-  ( IsHeading heading k v
-  , Member name tables ~ 'False
-  , KnownSymbol name
-  , table ~ (name ::: Table heading k v)
+  forall namedTable name heading k v tables.
+  ( Member name tables ~ 'False
+  , IsHeading heading k v
+  , Ord (Tuple k)
+  , namedTable ~ (name ::: Table heading k v)
   ) =>
-  Database tables ->
-  Database (name ::: Table heading k v ': tables)
-createTable = CreateTable (Var @name) (MkTable :: Table heading k v)
+  DBStatement tables ->
+  DBStatement (name ::: Table heading k v ': tables)
+createTable = CreateTable
 
 insert ::
   forall name tables heading k v.
   ( IsHeading heading k v
   , Table heading k v ~ (tables :! name)
-  , KnownSymbol name
+  , (MemDB' tables :! name) ~ M.Map (Tuple k) (Tuple v)
+  , IsMember name (M.Map (Tuple k) (Tuple v)) (MemDB' tables)
+  , Updatable name (M.Map (Tuple k) (Tuple v)) (MemDB' tables) (MemDB' tables)
+  , Ord (Tuple k)
   ) =>
-  Tuple (TableHeading (tables :! name)) ->
-  Database tables ->
-  Database tables
-insert = Insert (Var @name) MkTable
+  Tuple heading ->
+  DBStatement tables ->
+  DBStatement tables
+insert tuple = TableStatement (Var @name) (Insert tuple :: TableOp heading k v)
 
 insertMany ::
   forall name tables heading k v t.
   ( IsHeading heading k v
   , Table heading k v ~ (tables :! name)
-  , KnownSymbol name
+  , (MemDB' tables :! name) ~ M.Map (Tuple k) (Tuple v)
+  , IsMember name (M.Map (Tuple k) (Tuple v)) (MemDB' tables)
+  , Updatable name (M.Map (Tuple k) (Tuple v)) (MemDB' tables) (MemDB' tables)
+  , Ord (Tuple k)
   , Foldable t
   ) =>
-  t (Tuple (TableHeading (tables :! name))) ->
-  Database tables ->
-  Database tables
+  t (Tuple heading) ->
+  DBStatement tables ->
+  DBStatement tables
 insertMany tuples db = foldr (insert @name) db tuples
 
 table ::
   forall name tables heading k v.
-  ( IsHeading heading k v
-  , Table heading k v ~ (tables :! name)
-  , KnownSymbol name
+  ( (tables :! name) ~ Table heading k v
+  , IsMember name (Table heading k v) tables
+  , IsMember name (M.Map (Tuple k) (Tuple v)) (MemDB' tables)
+  , IsHeading heading k v
   ) =>
   Query heading tables
 table = Identity (Var @name) (MkTable :: Table heading k v)
@@ -82,11 +97,11 @@ project = Project @heading'
 (><) = Join
 
 extend ::
-    forall (l :: Symbol) (a :: Type) (t :: [Mapping Symbol Type]) tables.
-    (Member l t ~ 'False) =>
-    (Tuple t -> a) ->
-    Query t tables ->
-    Query (l ::: a ': t) tables
+  forall (l :: Symbol) (a :: Type) (t :: [Mapping Symbol Type]) tables.
+  (Member l t ~ 'False) =>
+  (Tuple t -> a) ->
+  Query t tables ->
+  Query (l ::: a ': t) tables
 extend = Extend Var
 
 summarize ::
@@ -107,7 +122,11 @@ group = Group (Var @name) (Proxy @attrs)
 
 ungroup ::
   forall l t tables nested rest.
-  (Tuple nested ~ (t :! l), IsMember l (Tuple nested) t, rest ~ (t :\ l), Submap rest t) =>
+  ( Tuple nested ~ (t :! l)
+  , IsMember l (Tuple nested) t
+  , rest ~ (t :\ l)
+  , Submap rest t
+  ) =>
   Query t tables ->
   Query (nested :++ rest) tables
 ungroup = Ungroup (Var @l) (Proxy @nested) Proxy
@@ -116,12 +135,6 @@ ungroup = Ungroup (Var @l) (Proxy @nested) Proxy
 (<|) = Ext (Var @k)
 
 infixr 5 <|
-
--- | Update the type at label l
-type family ChangeType (l :: Symbol) (t' :: Type) (t :: [Mapping Symbol Type]) where
-  ChangeType l a (l ::: b ': rest) = l ::: a ': rest
-  ChangeType l a (l' ::: b ': rest) = l' ::: b ': ChangeType l a rest
-  ChangeType l a '[] = '[]
 
 -- | Lens for getting a column out of a tuple
 col ::
@@ -140,3 +153,10 @@ col = lens (lookp (Var @label)) (`update` (Var @label))
      2  Jones Blake
 |]
 -}
+
+runQueryDB :: Query t tables -> DBStatement tables -> [Tuple t]
+runQueryDB q = runQuery q . materializeDB
+
+-- for the repl
+testQuery :: Show (Tuple t) => DBStatement tables -> Query t tables -> IO ()
+testQuery db q = runQueryDB q db & mapM_ Relude.print

--- a/src/QueryLanguage/Fancy/Examples.hs
+++ b/src/QueryLanguage/Fancy/Examples.hs
@@ -2,7 +2,7 @@
 module QueryLanguage.Fancy.Examples where
 
 import qualified Control.Foldl as L
-import Control.Lens hiding (Empty, Identity, (<|), (<|))
+import Control.Lens hiding (Empty, Identity, (<|))
 import Data.Binary
 import Data.Type.Map
 import Data.Type.Set (Sort)
@@ -10,6 +10,7 @@ import GHC.TypeLits
 import QueryLanguage.Fancy
 import QueryLanguage.Fancy.API
 import Relude hiding (Identity, group)
+import qualified Prelude as P
 
 -- The running example
 -- ╔═════════════════════════════════════════════════════════════════╗
@@ -56,7 +57,9 @@ type SPHeading = '["S#" ::: Int, "P#" ::: Int, "QTY" ::: Int]
 
 type SP = "suppliers-parts" ::: T SPHeading '["S#", "P#"]
 
-type Tables = AsMap '[Suppliers, Parts, SP]
+-- TODO: The ordering has to agree with the createTable calls. We should
+-- normalize instead
+type Tables = '[SP, Parts, Suppliers]
 
 s :: Query _ Tables
 s = table @"suppliers"
@@ -141,5 +144,3 @@ db =
       )
 
 -- & DeleteTable (Var @"suppliers")
-
-memDB = materializeDB db

--- a/src/QueryLanguage/Fancy/Examples.hs
+++ b/src/QueryLanguage/Fancy/Examples.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 -- | Example uses of fancy query language
 module QueryLanguage.Fancy.Examples where
 
@@ -99,6 +100,7 @@ spTup1, spTup2 :: Tuple (AsMap SPHeading)
 spTup1 = asMap @SPHeading $ 1 <| 1 <| 300 <| Empty
 spTup2 = asMap @SPHeading $ 1 <| 2 <| 200 <| Empty
 
+db :: DBStatement _ Ord Unconstrained
 db =
   EmptyDB
     & createTable @Suppliers


### PR DESCRIPTION
Initially, this was to get around a heterogeneous list of different map types for every table, but I figured out how to reuse the tuple mechanism for that here.